### PR TITLE
Update main.tf

### DIFF
--- a/single-web-server/main.tf
+++ b/single-web-server/main.tf
@@ -27,7 +27,7 @@ resource "aws_instance" "example" {
               nohup busybox httpd -f -p "${var.server_port}" &
               EOF
 
-  tags {
+  tags = {
     Name = "terraform-example"
   }
 }


### PR DESCRIPTION
Line 30 should read tags = {
otherwise 'terraform plan' throws an
Error: Unsupported block type
  on main.tf line 30, in resource "aws_instance" "example":

Using Terraform v0.12.0